### PR TITLE
ci: make the Pages deploy survive job re-runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,10 +30,16 @@ jobs:
         run: uv pip install .[dev]
       - name: Build documentation
         run: uv run pdoc -o docs/pdoc src/oai_pmh_client
+      # The artifact name includes the run attempt so that re-running the job
+      # works: artifacts from earlier attempts persist on the run, and
+      # deploy-pages fails if more than one artifact shares its name.
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/pdoc
+          name: github-pages-${{ github.run_attempt }}
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}


### PR DESCRIPTION
The docs deploy on main for the #13 merge failed twice. The first failure was a transient GitHub Pages error ("Deployment failed, try again later"). Re-running the failed job then hit a second, self-inflicted failure: "Multiple artifacts named github-pages were unexpectedly found for this workflow run. Artifact count is 2."

The cause is that artifacts from earlier attempts persist on the workflow run, and actions/deploy-pages@v4 refuses to deploy when more than one artifact matches its expected name. So any re-run of the deploy job is guaranteed to fail after the upload step has run once.

This names the Pages artifact after the run attempt (github-pages-1, github-pages-2, ...) on both the upload and deploy steps, so each attempt only sees its own artifact and re-runs work.

Merging this will also push a fresh run to main, which should get the current docs (including the 1.1.0 API changes) deployed.

https://claude.ai/code/session_01NAgqi1tHTRkeQj8Lz3MmvZ